### PR TITLE
Removed a ghost Article in index.js

### DIFF
--- a/include.js
+++ b/include.js
@@ -2891,14 +2891,6 @@ let cards = [
     author: 'Nachiketa Dhal',
     githubLink: 'https://github.com/NachiketaDhal'
   },
-
-  {
-    artName: 'Darksaber',
-    pageLink: './Art/Darksaber/index.html',
-    imageLink: './Art/Darksaber/darksaber.gif',
-    author: 'Rohan Yadav',
-    githubLink: 'https://github.com/lmNoob'
-  },
   {
     artName: 'Falling Leaves',
     pageLink: './Art/ThesllaDev/index.html',


### PR DESCRIPTION
In the "include.js" file there's an article (artName: 'Darksaber') lines 2895-2901 that isn't available anymore (the gif isn't showing) 
and I can't find the root Art directory where this user should have the article's files attached. 